### PR TITLE
Replace <arc object>.clone() with Arc::clone(&obj)

### DIFF
--- a/src/nt.rs
+++ b/src/nt.rs
@@ -40,7 +40,7 @@ impl NetworkTables<Client> {
     /// This function should _only_ be called if you are certain that the previous connection is dead.
     /// Connection status can be determined using callbacks specified with `add_connection_callback`.
     pub async fn reconnect(&mut self) {
-        let rt_state = self.state.clone();
+        let rt_state = Arc::clone(&self.state);
 
         let (close_tx, close_rx) = channel::<()>(1);
         let (packet_tx, packet_rx) = unbounded::<Box<dyn Packet>>();
@@ -82,7 +82,7 @@ impl NetworkTables<Client> {
     /// Connection status can be determined using callbacks specified with `add_connection_callback`.
     #[cfg(feature = "websocket")]
     pub async fn reconnect_ws(&mut self) {
-        let rt_state = self.state.clone();
+        let rt_state = Arc::clone(&self.state);
 
         let (close_tx, close_rx) = channel::<()>(1);
         let (packet_tx, packet_rx) = unbounded::<Box<dyn Packet>>();

--- a/src/proto/client.rs
+++ b/src/proto/client.rs
@@ -54,7 +54,7 @@ impl ClientState {
             next_rpc_id: 0,
         }));
 
-        let rt_state = state.clone();
+        let rt_state = Arc::clone(&state);
         thread::spawn(move || {
             let mut rt = Runtime::new().unwrap();
             let mut tx2 = ready_tx.clone();
@@ -89,7 +89,7 @@ impl ClientState {
             next_rpc_id: 0,
         }));
 
-        let rt_state = state.clone();
+        let rt_state = Arc::clone(&state);
         thread::spawn(move || {
             let mut rt = Runtime::new().unwrap();
 

--- a/src/proto/client/conn.rs
+++ b/src/proto/client/conn.rs
@@ -35,7 +35,7 @@ pub async fn connection(
     let addr = conn.local_addr().unwrap();
     let (mut tx, mut rx) = NTCodec.framed(conn).split();
 
-    let rx_state = state.clone();
+    let rx_state = Arc::clone(&state);
     tokio::spawn(async move {
         while let Some(msg) = rx.next().await {
             if let Ok(packet) = msg {
@@ -61,7 +61,7 @@ pub async fn connection(
         }
     });
 
-    let tick_state = state.clone();
+    let tick_state = Arc::clone(&state);
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(Duration::new(1, 0));
 
@@ -77,7 +77,7 @@ pub async fn connection(
 
     let mut rx = select(packet_rx.map(Either::Left), close_rx.map(Either::Right));
 
-    let tx_state = state.clone();
+    let tx_state = Arc::clone(&state);
     tx.send(Box::new(ClientHello::new(NTVersion::V3, client_name)))
         .await
         .unwrap();
@@ -153,7 +153,7 @@ pub async fn connection_ws(
         }
     });
 
-    let tick_state = state.clone();
+    let tick_state = Arc::clone(&state);
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(Duration::new(1, 0));
 

--- a/src/proto/server.rs
+++ b/src/proto/server.rs
@@ -47,7 +47,7 @@ impl ServerState {
             rpc_actions: HashMap::new(),
         }));
 
-        let rt_state = state.clone();
+        let rt_state = Arc::clone(&state);
         spawn_rt(ip, rt_state, close_rx);
 
         state

--- a/src/proto/server/conn.rs
+++ b/src/proto/server/conn.rs
@@ -49,7 +49,7 @@ pub async fn connection(
                     addr,
                     NTCodec.framed(conn).map_err(Error::from),
                     rx,
-                    state.clone(),
+                    Arc::clone(&state),
                 ));
             }
         }
@@ -133,7 +133,7 @@ async fn handle_ws_conn(
         addr,
         codec.map_err(Error::from),
         rx,
-        state.clone(),
+        Arc::clone(&state),
     ));
     Ok(())
 }


### PR DESCRIPTION
Prevent potential collision with underlying object with potential clone method.

While current code is properly using Arc::clone internally, It can potentially get mixed up in the future.

This is discussed in the rust docs here...
https://doc.rust-lang.org/std/sync/struct.Arc.html#deref-behavior